### PR TITLE
feat(nx-mikro-orm-cli): add mikro-orm v5 support

### DIFF
--- a/packages/nx-mikro-orm-cli/src/executors/run/run.impl.spec.ts
+++ b/packages/nx-mikro-orm-cli/src/executors/run/run.impl.spec.ts
@@ -74,6 +74,7 @@ describe("MikroORM CLI Executor", () => {
     const output = await executor.default(input, context);
 
     const shim = JSON.stringify({
+      devDependencies: { "mikro-orm": "*" },
       "mikro-orm": input.config
     });
 
@@ -105,6 +106,7 @@ describe("MikroORM CLI Executor", () => {
     const output = await executor.default(input, context);
 
     const shim = JSON.stringify({
+      devDependencies: { "mikro-orm": "*" },
       "mikro-orm": input.config
     });
 

--- a/packages/nx-mikro-orm-cli/src/executors/run/run.impl.ts
+++ b/packages/nx-mikro-orm-cli/src/executors/run/run.impl.ts
@@ -36,6 +36,7 @@ export default async (options: MikroOrmExecutorSchema, context: ExecutorContext)
   const renamedPackageJsonPath = await renameExistingPackageJson(projectPackageJsonPath);
 
   const shim = JSON.stringify({
+    "devDependencies": { "mikro-orm": "*"  },
     "mikro-orm": options.config
   });
 


### PR DESCRIPTION
The latest `@mikro-orm/cli` version checks package.json has `@mikro-orm/cli` listed as a dependency or throws:

```
$ Error: @mikro-orm/cli needs to be installed as a local dependency!
```

Adds dependency to mocked package.json and updates tests.