### PR TITLE
feat(nx-mikro-orm-cli): support mikro-orm v5

### DIFF
--- a/packages/nx-mikro-orm-cli/src/executors/run/run.impl.ts
+++ b/packages/nx-mikro-orm-cli/src/executors/run/run.impl.ts
@@ -43,7 +43,12 @@ export default async (options: MikroOrmExecutorSchema, context: ExecutorContext)
 
   try {
     const { stderr, stdout } = await exec(`${binPath} ${options.args}`, {
-      cwd: projectPath
+      cwd: projectPath,
+      env: {
+        // MikroORM v5 requires a global installation of the CLI and drivers; but since we always execute the CLI in the workspace root,
+        // this is an irrelevant requirement, see https://github.com/mikro-orm/mikro-orm/commit/8952149a78be5ba527ae1614cb1eb36d6d8d1dd9
+        MIKRO_ORM_ALLOW_GLOBAL_CLI: "1"
+      }
     });
 
     process.stderr.write(stderr);


### PR DESCRIPTION
Add support for MikroORM v5.

Sets the environment variable of `MIKRO_ORM_ALLOW_GLOBAL_CLI` to true when executing the CLI with child_process. Since the NX executor always executes the MikroORM CLI located in your node_modules/.bin of your workspace root, this validation was irrelevant, as node will throw an error if MikroORM CLI was not installed in your NX workspace.