### PR TITLE
fix(nx-mikro-orm-cli): executor fails to run on MacOS

### DIFF
--- a/packages/nx-mikro-orm-cli/src/executors/run/run.impl.ts
+++ b/packages/nx-mikro-orm-cli/src/executors/run/run.impl.ts
@@ -45,10 +45,10 @@ export default async (options: MikroOrmExecutorSchema, context: ExecutorContext)
     const { stderr, stdout } = await exec(`${binPath} ${options.args}`, {
       cwd: projectPath,
       env: {
-        ...process.env,
         // MikroORM v5 requires a global installation of the CLI and drivers; but since we always execute the CLI in the workspace root,
         // this is an irrelevant requirement, see https://github.com/mikro-orm/mikro-orm/commit/8952149a78be5ba527ae1614cb1eb36d6d8d1dd9
-        MIKRO_ORM_ALLOW_GLOBAL_CLI: "1"
+        MIKRO_ORM_ALLOW_GLOBAL_CLI: "1",
+        ...process.env,
       }
     });
 

--- a/packages/nx-mikro-orm-cli/src/executors/run/run.impl.ts
+++ b/packages/nx-mikro-orm-cli/src/executors/run/run.impl.ts
@@ -45,6 +45,7 @@ export default async (options: MikroOrmExecutorSchema, context: ExecutorContext)
     const { stderr, stdout } = await exec(`${binPath} ${options.args}`, {
       cwd: projectPath,
       env: {
+        ...process.env,
         // MikroORM v5 requires a global installation of the CLI and drivers; but since we always execute the CLI in the workspace root,
         // this is an irrelevant requirement, see https://github.com/mikro-orm/mikro-orm/commit/8952149a78be5ba527ae1614cb1eb36d6d8d1dd9
         MIKRO_ORM_ALLOW_GLOBAL_CLI: "1"


### PR DESCRIPTION
Fixes the following error on MacOS by preserving existing environment variables when calling `exec`.

```bash
> Executing task: npx nx run api:mikro-orm --parallel --args='schema:create --dump' <

> nx run api:mikro-orm --args="schema:create --dump"

Command failed: /.../node_modules/.bin/mikro-orm schema:create --dump
env: node: No such file or directory
```

See https://stackoverflow.com/a/67059161/6618124