### PR TITLE
ci(): fix pr issue, run build step before testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,11 @@ name: Nx Affected Tests
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
   pull_request:
-    branches: [master]
+    branches:
+      - master
 
 jobs:
   push:
@@ -14,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node: [12, 14, 15, 16]
 
     steps:
       - name: Checkout master branch
@@ -27,17 +29,20 @@ jobs:
         with:
           main-branch-name: "master"
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
           cache: "npm"
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Run Affected Tests
-        run: npx nx affected --target=test
+      - name: Build affected libraries
+        run: npx nx affected --target=build --parallel --max-parallel=3
+
+      - name: Run tests for affected libraries
+        run: npx nx affected --target=test --parallel --max-parallel=2
 
   pr:
     if: ${{ github.event_name == 'pull_request' }}
@@ -46,7 +51,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node: [12, 14, 15, 16]
 
     steps:
       - name: Checkout master branch
@@ -60,14 +65,17 @@ jobs:
         with:
           main-branch-name: "master"
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
           cache: "npm"
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Run Affected Tests
-        run: npx nx affected --target=test
+      - name: Build affected libraries
+        run: npx nx affected --target=build --parallel --max-parallel=3
+
+      - name: Run tests for affected libraries
+        run: npx nx affected --target=test --parallel --max-parallel=2


### PR DESCRIPTION
Adds a build step before running the tests, the output can then be used by Nx to calculate which tests to run.

Some minor updates with Node versions as well that are unrelated to the error but improve readability (imo).